### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,6 +6,5 @@
   "repo": "googleapis/nodejs-precise-date",
   "distribution_name": "@google-cloud/precise-date",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/precise-date/latest",
-  "api_shortname": "precise-date",
-  "library_type": "GAPIC_AUTO"
+  "library_type": "OTHER"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -7,5 +7,5 @@
   "distribution_name": "@google-cloud/precise-date",
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/precise-date/latest",
   "api_shortname": "precise-date",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,9 +1,11 @@
 {
   "name": "precise-date",
   "name_pretty": "Google Cloud Precise Date",
-  "release_level": "ga",
+  "release_level": "stable",
   "language": "nodejs",
   "repo": "googleapis/nodejs-precise-date",
   "distribution_name": "@google-cloud/precise-date",
-  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/precise-date/latest"
+  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/precise-date/latest",
+  "api_shortname": "precise-date",
+  "library_type": ""
 }


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 